### PR TITLE
Issue 142 - display correct field in repair request form

### DIFF
--- a/src/components/Forms/prepopulated-repair-request-form.tsx
+++ b/src/components/Forms/prepopulated-repair-request-form.tsx
@@ -46,7 +46,7 @@ export default function PrepopulatedRepairAttemptForm({
       isRepaired: status,
       isSparePartsNeeded: isSparePartsNeeded,
       spareParts: props.spareParts,
-      repairComment: props.comment
+      repairComment: props.repairComment
     }
   });
 


### PR DESCRIPTION
## Change Summary
perhaps the biggest change of all time:
[src/components/Forms/prepopulated-repair-request-form.tsx](https://github.com/codersforcauses/repair-labs/compare/issue-142-Fix_repair_request_Job_Description_displaying_wrong_field_in_frontend?expand=1#diff-d80e772ce12ebf35de26eed6bfbc73ca5bf795434f0432b491a3b94c5ea1fc26)
```diff
- repairComment: props.comment
+ repairComment: props.repairComment
```

### Change Form
- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
N/A